### PR TITLE
geo-accuracy

### DIFF
--- a/src/screens/fireScreen.tsx
+++ b/src/screens/fireScreen.tsx
@@ -154,7 +154,6 @@ export default function FireScreen() {
 				) : (
 					<FullErrorView item="loading" action={null}></FullErrorView>
 				)}
-				<ErrorBar />
 			</LinearGradient>
 		</>
 	);


### PR DESCRIPTION
Der 'location.accuracy' Fehler wird erst angezeigt nachdem die Standortgenauigkeit zweimal infolge zu schlecht war